### PR TITLE
Fix load_data in movie-lens controller

### DIFF
--- a/controllers/movie-lens/src/bin/load_data.rs
+++ b/controllers/movie-lens/src/bin/load_data.rs
@@ -76,12 +76,6 @@ fn insert_ratings(conn: &PgConnection) -> Result<(), Error> {
             let movie_id: i32 = record[1].parse()?;
             let score: f64 = record[2].parse()?;
 
-            match controller.items_by(&SearchBy::id(&movie_id.to_string())) {
-                Ok(movies) if movies.is_empty() => continue,
-                Err(_) => continue,
-                Ok(_) => {}
-            }
-
             ratings.push(NewRating {
                 score,
                 user_id,


### PR DESCRIPTION
I just removed the lines where the checking occurs. There's not inconsistency in movie-lens database so no foreign keys errors should happen. owo
```rust
            match controller.items_by(&SearchBy::id(&movie_id.to_string())) {
                Ok(movies) if movies.is_empty() => continue,
                 Err(_) => continue,
                 Ok(_) => {}
            }
```