### PR TITLE
Augmented parser for new functions and subprompts (sim_matrix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ books = { version = "*", path = "controllers/books" }
 controller = { version = "*", path = "controller" }
 movie-lens= { version = "*", path = "controllers/movie-lens" }
 movie-lens-small = { version = "*", path = "controllers/movie-lens-small" }
-shelves = {version = "*", path = "controllers/shelves"}
+shelves = {version = "*", path = "controllers/shelves" }
 nom = "5"
 engine = { version = "*", path = "engine" }
 simple-movie = { version = "*", path = "controllers/simple-movie" }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -99,7 +99,7 @@ where
         )
     }
 
-    pub fn knn_predict(
+    pub fn user_predict(
         &self,
         k: usize,
         user: &User,

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -24,7 +24,6 @@ pub mod utils;
 use crate::{distances::users::Method as UserMethod, maped_distance::MapedDistance};
 use controller::{Controller, Entity};
 use knn::{Knn, MaxHeapKnn, MinHeapKnn};
-use similarity_matrix::SimilarityMatrix;
 use std::{hash::Hash, marker::PhantomData};
 
 pub struct Engine<'a, C, User, UserId, Item, ItemId>
@@ -173,15 +172,6 @@ where
 
         prediction
     }
-
-    pub fn similarity_matrix(
-        &self,
-        m: usize,
-        n: usize,
-        threshold: usize,
-    ) -> SimilarityMatrix<'a, C, User, UserId, Item, ItemId> {
-        SimilarityMatrix::new(&self.controller, m, n, threshold)
-    }
 }
 
 #[cfg(feature = "test-engine")]
@@ -308,13 +298,11 @@ mod tests {
         use std::time::Instant;
 
         let controller = MovieLensSmallController::new()?;
-        let engine = Engine::with_controller(&controller);
-        let mut sim_matrix = engine.similarity_matrix(10000, 10000, 100);
+        let mut sim_matrix = SimilarityMatrix::new(&controller, 10000, 10000, 100);
 
         let now = Instant::now();
         let _matrix = sim_matrix.get_chunk(0, 0);
         println!("Elapsed: {}", now.elapsed().as_secs_f64());
-        //println!("{:#?}", matrix);
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use engine::Engine;
 use movie_lens::MovieLensController;
 use movie_lens_small::MovieLensSmallController;
 use parser::{Database, Statement};
+use shelves::ShelvesController;
 use simple_movie::SimpleMovieController;
 use std::{fmt::Display, hash::Hash, time::Instant};
 
@@ -47,10 +48,6 @@ macro_rules! prompt {
             Err(e) => Err(e),
         }
     }};
-}
-
-fn similarity_matrix_shell() {
-    todo!()
 }
 
 fn database_connected_prompt<C, User, UserId, Item, ItemId>(
@@ -187,7 +184,7 @@ where
                         println!("Operation took {:.4} seconds", elapsed);
                     }
 
-                    Statement::KnnPredict(k, searchby_user, searchby_item, method, chunks_opt) => {
+                    Statement::UserPredict(k, searchby_user, searchby_item, method, chunks_opt) => {
                         let users = match controller.users_by(&searchby_user) {
                             Ok(users) => users,
                             Err(e) => {
@@ -206,7 +203,7 @@ where
 
                         let now = Instant::now();
                         let prediction =
-                            engine.knn_predict(k, &users[0], &items[0], method, chunks_opt);
+                            engine.user_predict(k, &users[0], &items[0], method, chunks_opt);
                         match prediction {
                             Some(predicted) => println!(
                                 "Predicted score for item with id({}) is {}",
@@ -264,6 +261,11 @@ fn main() -> Result<(), Error> {
                             Database::Books => {
                                 database_connected_prompt(BooksController::new()?, "books")?
                             }
+
+                            Database::Shelves => {
+                                database_connected_prompt(ShelvesController::new()?, "shelves")?
+                            }
+
                             Database::SimpleMovie => database_connected_prompt(
                                 SimpleMovieController::new()?,
                                 "simple-movie",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,7 +42,11 @@ pub enum Statement {
     UserKnn(usize, SearchBy, UserMethod, Option<usize>),
     UserPredict(usize, SearchBy, SearchBy, UserMethod, Option<usize>),
     ItemPredict(SearchBy, SearchBy, ItemMethod, Option<usize>),
-    SimilarityMatrix(usize, usize, usize, ItemMethod),
+
+    // Specific for similarity matrix
+    EnterSimilarityMatrix(usize, usize, usize, ItemMethod),
+    SimMatrixGet(usize, usize),
+    SimMatrixMoveTo(usize, usize),
 }
 
 fn parse_user_method(input: &str) -> IResult<&str, UserMethod> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -339,8 +339,8 @@ mod tests {
     }
 
     #[test]
-    fn distance_statement() {
-        let parsed = parse_statement("distance(id('32a'), id('32b'), euclidean)");
+    fn user_distance_statement() {
+        let parsed = parse_statement("user_distance(id('32a'), id('32b'), euclidean)");
         let expected = (
             "",
             Statement::UserDistance(
@@ -354,8 +354,23 @@ mod tests {
     }
 
     #[test]
-    fn knn_statement() {
-        let parsed = parse_statement("knn(4, id('324x'), minkowski(3))");
+    fn item_distance_statement() {
+        let parsed = parse_statement("item_distance(id('32a'), id('32b'), adj_cosine)");
+        let expected = (
+            "",
+            Statement::ItemDistance(
+                SearchBy::id("32a"),
+                SearchBy::id("32b"),
+                ItemMethod::AdjCosine,
+            ),
+        );
+
+        assert_eq!(parsed, Ok(expected));
+    }
+
+    #[test]
+    fn user_knn_statement() {
+        let parsed = parse_statement("user_knn(4, id('324x'), minkowski(3))");
         let expected = (
             "",
             Statement::UserKnn(4, SearchBy::id("324x"), UserMethod::Minkowski(3), None),
@@ -363,7 +378,7 @@ mod tests {
 
         assert_eq!(parsed, Ok(expected));
 
-        let parsed = parse_statement("knn(4, id('324x'), minkowski(3), 10)");
+        let parsed = parse_statement("user_knn(4, id('324x'), minkowski(3), 10)");
         let expected = (
             "",
             Statement::UserKnn(4, SearchBy::id("324x"), UserMethod::Minkowski(3), Some(10)),
@@ -373,8 +388,9 @@ mod tests {
     }
 
     #[test]
-    fn predict_statement() {
-        let parsed = parse_statement("predict(4, id('324x'), name('Alien'), minkowski(3))");
+    fn user_predict_statement() {
+        let parsed =
+            parse_statement("user_based_predict(4, id('324x'), name('Alien'), minkowski(3))");
         let expected = (
             "",
             Statement::UserPredict(
@@ -388,7 +404,8 @@ mod tests {
 
         assert_eq!(parsed, Ok(expected));
 
-        let parsed = parse_statement("predict(4, id('324x'), name('Alien'), minkowski(3), 100)");
+        let parsed =
+            parse_statement("user_based_predict(4, id('324x'), name('Alien'), minkowski(3), 100)");
         let expected = (
             "",
             Statement::UserPredict(
@@ -404,6 +421,36 @@ mod tests {
     }
 
     #[test]
+    fn item_predict_statement() {
+        let parsed = parse_statement("item_based_predict(id('324x'), name('Alien'), adj_cosine)");
+        let expected = (
+            "",
+            Statement::ItemPredict(
+                SearchBy::id("324x"),
+                SearchBy::name("Alien"),
+                ItemMethod::AdjCosine,
+                None,
+            ),
+        );
+
+        assert_eq!(parsed, Ok(expected));
+
+        let parsed =
+            parse_statement("item_based_predict(id('324x'), name('Alien'), adj_cosine, 100)");
+        let expected = (
+            "",
+            Statement::ItemPredict(
+                SearchBy::id("324x"),
+                SearchBy::name("Alien"),
+                ItemMethod::AdjCosine,
+                Some(100),
+            ),
+        );
+
+        assert_eq!(parsed, Ok(expected));
+    }
+
+    #[test]
     fn parse_invalid_line() {
         let parsed = parse_line("query_user(id())xx");
         assert!(parsed.is_none());
@@ -411,7 +458,7 @@ mod tests {
 
     #[test]
     fn parse_valid_line() {
-        let parsed = parse_line("knn(5, name('Patrick C'), cosine)");
+        let parsed = parse_line("user_knn(5, name('Patrick C'), cosine)");
         assert_eq!(
             parsed,
             Some(Statement::UserKnn(

--- a/src/parser/basics.rs
+++ b/src/parser/basics.rs
@@ -1,0 +1,67 @@
+use nom::bytes::complete::{tag, take_till1, take_while, take_while1};
+use nom::character::complete::{char, digit1};
+use nom::combinator::map_res;
+use nom::{sequence::delimited, IResult};
+
+pub(crate) fn parse_ident(input: &str) -> IResult<&str, &str> {
+    take_while1(|c: char| c.is_alphanumeric() || c == '_' || c == '-')(input)
+}
+
+pub(crate) fn parse_string(input: &str) -> IResult<&str, &str> {
+    delimited(char('\''), take_till1(|c: char| c == '\''), char('\''))(input)
+}
+
+pub(crate) fn parse_number(input: &str) -> IResult<&str, i64> {
+    map_res(digit1, |s: &str| s.parse::<i64>())(input)
+}
+
+pub(crate) fn parse_separator(input: &str) -> IResult<&str, &str> {
+    delimited(
+        take_while(|c: char| c == ' '),
+        tag(","),
+        take_while(|c: char| c == ' '),
+    )(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_idents() {
+        let parsed = parse_ident("ident_is-ok");
+        let expected = ("", "ident_is-ok");
+
+        assert_eq!(parsed, Ok(expected));
+
+        let parsed = parse_ident("this is not ok");
+        let expected = (" is not ok", "this");
+
+        assert_eq!(parsed, Ok(expected));
+    }
+
+    #[test]
+    fn test_parse_string() {
+        let parsed = parse_string("'holo, cómo estás?'");
+        let expected = ("", "holo, cómo estás?");
+
+        assert_eq!(parsed, Ok(expected));
+
+        let parsed = parse_string("'holo' #wed2@ws");
+        let expected = (" #wed2@ws", "holo");
+
+        assert_eq!(parsed, Ok(expected))
+    }
+
+    #[test]
+    fn test_parse_numbers() {
+        let parsed = parse_number("12345");
+        let expected = ("", 12345);
+
+        assert_eq!(parsed, Ok(expected));
+
+        let parsed = parse_number("12c3");
+        let expected = ("c3", 12);
+        assert_eq!(parsed, Ok(expected));
+    }
+}


### PR DESCRIPTION
I'm working on the logic to parse these new functions:

- [x] item_distance
- [x] item_based_predict
- [x] enter_sim_matrix
- [x] get (only in sim_matrix)
- [x] move(only in sim_matrix)

I also changed some names in the Engine and the statements themself. Still work in progress (will close #16 