### PR TITLE
Refactor some code and remove some Clone constraints on possibly heavy objects

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -78,9 +78,9 @@ where
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
-pub type Ratings<ItemId> = HashMap<ItemId, f64>;
-pub type MapedRatings<UserId, ItemId> = HashMap<UserId, Ratings<ItemId>>;
 pub type ItemsUsers<ItemId, UserId> = HashMap<ItemId, HashSet<UserId>>;
+pub type Ratings<ItemId, Value = f64> = HashMap<ItemId, Value>;
+pub type MapedRatings<UserId, ItemId, Value = f64> = HashMap<UserId, Ratings<ItemId, Value>>;
 
 pub struct LazyUserChunks<'a, User, UserId, Item, ItemId> {
     curr_offset: usize,

--- a/engine/src/distances/items.rs
+++ b/engine/src/distances/items.rs
@@ -1,10 +1,10 @@
 use crate::error::ErrorKind;
-use controller::Ratings;
+use controller::{MapedRatings, Ratings};
 use num_traits::float::Float;
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
-    ops::{AddAssign, Mul, Sub},
+    ops::{Add, AddAssign, Div, Mul, Sub},
 };
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -13,43 +13,47 @@ pub enum Method {
     SlopeOne,
 }
 
-pub fn adjusted_cosine_means<U, K, V>(vecs: &HashMap<U, HashMap<K, V>>) -> HashMap<U, V>
+pub type Means<UserId, Value> = HashMap<UserId, Value>;
+
+pub fn adjusted_cosine_means<UserId, ItemId, Value>(
+    vecs: &MapedRatings<UserId, ItemId, Value>,
+) -> Means<&UserId, Value>
 where
-    U: Hash + Eq + Clone,
-    K: Hash + Eq,
-    V: Float + AddAssign,
+    UserId: Hash + Eq + Clone,
+    ItemId: Hash + Eq,
+    Value: Float + AddAssign,
 {
-    let mut means = HashMap::new();
+    let mut means = Means::new();
     for (id, vec) in vecs {
         let mut mean = None;
         let mut n = 0;
 
         for x in vec.values() {
-            *mean.get_or_insert_with(V::zero) += *x;
+            *mean.get_or_insert_with(Value::zero) += *x;
             n += 1;
         }
 
         if let Some(mean) = mean {
-            let mean = mean / V::from(n).unwrap();
-            means.insert(id.to_owned(), mean);
+            let mean = mean / Value::from(n).unwrap();
+            means.insert(id, mean);
         }
     }
 
     means
 }
 
-pub fn fast_adjusted_cosine<U, K, V>(
-    means: &HashMap<U, V>,
-    vecs: &HashMap<U, HashMap<K, V>>,
-    users_a: &HashSet<U>,
-    users_b: &HashSet<U>,
-    a: &K,
-    b: &K,
-) -> Result<V, ErrorKind>
+pub fn fast_adjusted_cosine<UserId, ItemId, Value>(
+    means: &Means<&UserId, Value>,
+    vecs: &MapedRatings<UserId, ItemId, Value>,
+    users_a: &HashSet<UserId>,
+    users_b: &HashSet<UserId>,
+    a: &ItemId,
+    b: &ItemId,
+) -> Result<Value, ErrorKind>
 where
-    U: Hash + Eq,
-    K: Hash + Eq,
-    V: Float + AddAssign + Sub + Mul,
+    UserId: Hash + Eq,
+    ItemId: Hash + Eq,
+    Value: Float + AddAssign + Sub + Mul,
 {
     let mut cov = None;
     let mut dev_a = None;
@@ -66,9 +70,9 @@ where
             means.get(common_user),
         ) {
             (Some(val_a), Some(val_b), Some(mean)) => {
-                *cov.get_or_insert_with(V::zero) += (*val_a - *mean) * (*val_b - *mean);
-                *dev_a.get_or_insert_with(V::zero) += (*val_a - *mean).powi(2);
-                *dev_b.get_or_insert_with(V::zero) += (*val_b - *mean).powi(2);
+                *cov.get_or_insert_with(Value::zero) += (*val_a - *mean) * (*val_b - *mean);
+                *dev_a.get_or_insert_with(Value::zero) += (*val_a - *mean).powi(2);
+                *dev_b.get_or_insert_with(Value::zero) += (*val_b - *mean).powi(2);
             }
             _ => continue,
         }
@@ -89,40 +93,55 @@ where
     }
 }
 
-pub fn slow_adjusted_cosine<U, K, V>(
-    vecs: &HashMap<U, HashMap<K, V>>,
-    users_a: &HashSet<U>,
-    users_b: &HashSet<U>,
-    a: &K,
-    b: &K,
-) -> Result<V, ErrorKind>
+pub fn slow_adjusted_cosine<UserId, ItemId, Value>(
+    vecs: &MapedRatings<UserId, ItemId, Value>,
+    users_a: &HashSet<UserId>,
+    users_b: &HashSet<UserId>,
+    a: &ItemId,
+    b: &ItemId,
+) -> Result<Value, ErrorKind>
 where
-    U: Hash + Eq + Clone,
-    K: Hash + Eq,
-    V: Float + AddAssign + Sub + Mul,
+    UserId: Hash + Eq + Clone,
+    ItemId: Hash + Eq,
+    Value: Float + AddAssign + Sub + Mul,
 {
     let means = adjusted_cosine_means(vecs);
     fast_adjusted_cosine(&means, vecs, users_a, users_b, a, b)
 }
 
-pub fn normalize_user_ratings<ItemId: Clone>(
-    ratings: &Ratings<ItemId>,
-    min_rating: f64,
-    max_rating: f64,
-) -> Result<Ratings<ItemId>, ErrorKind> {
-    if max_rating - min_rating == 0.0 {
+pub fn normalize_user_ratings<ItemId, Value>(
+    ratings: &Ratings<ItemId, Value>,
+    min_rating: Value,
+    max_rating: Value,
+) -> Result<Ratings<&ItemId, Value>, ErrorKind>
+where
+    ItemId: Hash + Eq,
+    Value: Float + Sub + Mul + Div,
+{
+    if (max_rating - min_rating).is_zero() {
         return Err(ErrorKind::DivisionByZero);
     }
 
-    let mut normalized_ratings = ratings.clone();
-
-    for (_, rating) in normalized_ratings.iter_mut() {
-        *rating = (2.0 * *rating - min_rating - max_rating) / (max_rating - min_rating);
+    let mut normalized_ratings = Ratings::new();
+    for (id, value) in ratings {
+        let two = Value::from(2.0).ok_or_else(|| ErrorKind::ConvertType)?;
+        let normalized = (two * (*value) - min_rating - max_rating) / (max_rating - min_rating);
+        normalized_ratings.insert(id, normalized);
     }
 
     Ok(normalized_ratings)
 }
 
-pub fn denormalize_user_rating(normalized_rating: f64, min_rating: f64, max_rating: f64) -> f64 {
-    (1.0 / 2.0) * ((normalized_rating + 1.0) * (max_rating - min_rating)) + min_rating
+pub fn denormalize_user_rating<Value>(
+    normalized_rating: Value,
+    min_rating: Value,
+    max_rating: Value,
+) -> Result<Value, ErrorKind>
+where
+    Value: Float + Sub + Add + Div + Mul,
+{
+    let one = Value::one();
+    let two = Value::from(2.0).ok_or_else(|| ErrorKind::ConvertType)?;
+
+    Ok((one / two) * ((normalized_rating + one) * (max_rating - min_rating)) + min_rating)
 }


### PR DESCRIPTION
I have changed some function signatures in the Engine struct and modified how User and Item are passed to the Engine, now they are all moved.
Some other functions now use references to avoid cloning too. Closes #25 