### PR TITLE
Optimization to Item based prediction using local storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "movie-lens-small",
  "num-traits",
  "rand",
+ "shelves",
  "simple-movie",
  "thiserror",
 ]

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -207,6 +207,7 @@ where
     fn maped_ratings_except(&self, user: &User) -> Result<MapedRatings<UserId, ItemId>>;
 
     fn get_range(&self) -> (f64, f64);
+    fn get_means(&self, users: &Vec<User>) -> HashMap<UserId, f64>;
 }
 
 pub mod error {

--- a/controllers/books/migrations/2020-06-15-014726_create_means/down.sql
+++ b/controllers/books/migrations/2020-06-15-014726_create_means/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE means;

--- a/controllers/books/migrations/2020-06-15-014726_create_means/up.sql
+++ b/controllers/books/migrations/2020-06-15-014726_create_means/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+CREATE TABLE means
+(
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    val FLOAT NOT NULL
+)

--- a/controllers/books/src/bin/load_means.rs
+++ b/controllers/books/src/bin/load_means.rs
@@ -1,0 +1,57 @@
+use anyhow::Error;
+use books::establish_connection;
+use books::models::{
+    books::{Book, NewBook},
+    ratings::NewRating,
+    users::{NewMean, NewUser, User},
+};
+use books::schema::{books as books_sc, means, ratings, users};
+use books::BooksController;
+use controller::{Controller, Entity};
+use diesel::pg::PgConnection;
+use diesel::{insert_into, prelude::*};
+use std::collections::HashMap;
+
+fn insert_means(conn: &PgConnection, new_means: &Vec<NewMean>) -> Result<(), Error> {
+    insert_into(means::table).values(new_means).execute(conn)?;
+
+    Ok(())
+}
+
+fn compute_mean(ratings: &HashMap<String, f64>) -> f64 {
+    if ratings.is_empty() {
+        return 0.0;
+    }
+
+    let mut mean = 0.0;
+    for (_, rating) in ratings {
+        mean += rating;
+    }
+    mean / ratings.len() as f64
+}
+
+fn main() -> Result<(), Error> {
+    let url = "postgres://postgres:@localhost/books";
+    let conn = establish_connection(url)?;
+
+    let controller = BooksController::new()?;
+
+    let users_iterator = controller.users_by_chunks(10000);
+    for user_chunk in users_iterator {
+        println!("Inserting new chunk");
+        let mut mean_chunk = Vec::new();
+        let maped_ratings = controller.maped_ratings_by(&user_chunk)?;
+        for user in user_chunk {
+            let user_id = user.get_id();
+            if maped_ratings.contains_key(&user_id) {
+                let mean = compute_mean(&maped_ratings[&user_id]);
+                mean_chunk.push(NewMean { user_id, val: mean });
+            } else {
+                mean_chunk.push(NewMean { user_id, val: 0.0 });
+            }
+        }
+        insert_means(&conn, &mean_chunk)?;
+    }
+
+    Ok(())
+}

--- a/controllers/books/src/lib.rs
+++ b/controllers/books/src/lib.rs
@@ -4,7 +4,11 @@ extern crate diesel;
 pub mod models;
 pub mod schema;
 
-use crate::models::{books::Book, ratings::Rating, users::User};
+use crate::models::{
+    books::Book,
+    ratings::Rating,
+    users::{Mean, User},
+};
 use crate::schema::{books, ratings, users};
 use anyhow::Error;
 use controller::{error::ErrorKind, Controller, MapedRatings, Ratings, SearchBy};
@@ -188,6 +192,19 @@ impl Controller<User, i32, Book, String> for BooksController {
 
     fn get_range(&self) -> (f64, f64) {
         (0., 10.)
+    }
+    fn get_means(&self, users: &Vec<User>) -> HashMap<i32, f64> {
+        let means = Mean::belonging_to(users)
+            .load::<Mean>(&self.pg_conn)
+            .unwrap();
+
+        let mut means_by_user = HashMap::new();
+
+        for mean in means {
+            means_by_user.insert(mean.user_id, mean.val);
+        }
+
+        means_by_user
     }
 }
 

--- a/controllers/books/src/models/users.rs
+++ b/controllers/books/src/models/users.rs
@@ -1,4 +1,4 @@
-use crate::schema::users;
+use crate::schema::{means, users};
 use common_macros::hash_map;
 use controller::Entity;
 use std::collections::HashMap;
@@ -28,6 +28,21 @@ impl Entity for User {
 
         map
     }
+}
+
+#[derive(Debug, Clone, Identifiable, Queryable, Associations)]
+#[belongs_to(User)]
+pub struct Mean {
+    pub id: i32,
+    pub user_id: i32,
+    pub val: f64,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[table_name = "means"]
+pub struct NewMean {
+    pub user_id: i32,
+    pub val: f64,
 }
 
 // To insert a new user into the database

--- a/controllers/books/src/schema.rs
+++ b/controllers/books/src/schema.rs
@@ -9,6 +9,14 @@ table! {
 }
 
 table! {
+    means (id) {
+        id -> Int4,
+        user_id -> Int4,
+        val -> Float8,
+    }
+}
+
+table! {
     ratings (id) {
         id -> Int4,
         user_id -> Int4,
@@ -25,11 +33,13 @@ table! {
     }
 }
 
+joinable!(means -> users (user_id));
 joinable!(ratings -> books (book_id));
 joinable!(ratings -> users (user_id));
 
 allow_tables_to_appear_in_same_query!(
     books,
+    means,
     ratings,
     users,
 );

--- a/controllers/movie-lens-small/migrations/2020-06-15-000503_create_means/down.sql
+++ b/controllers/movie-lens-small/migrations/2020-06-15-000503_create_means/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE means;

--- a/controllers/movie-lens-small/migrations/2020-06-15-000503_create_means/up.sql
+++ b/controllers/movie-lens-small/migrations/2020-06-15-000503_create_means/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+CREATE TABLE means
+(
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    val FLOAT NOT NULL
+)

--- a/controllers/movie-lens-small/src/bin/load_means.rs
+++ b/controllers/movie-lens-small/src/bin/load_means.rs
@@ -1,0 +1,56 @@
+use anyhow::Error;
+use controller::{Controller, Entity};
+use diesel::pg::PgConnection;
+use diesel::{insert_into, prelude::*};
+use movie_lens_small::establish_connection;
+use movie_lens_small::models::{
+    movies::{Movie, NewMovie},
+    ratings::NewRating,
+    users::{NewMean, NewUser, User},
+};
+use movie_lens_small::schema::{means, movies, ratings, users};
+use movie_lens_small::MovieLensSmallController;
+use std::collections::HashMap;
+
+fn create_mean(conn: &PgConnection, user_id: i32, mean: f64) -> Result<(), Error> {
+    let new_mean = NewMean { user_id, val: mean };
+
+    insert_into(means::table).values(&new_mean).execute(conn)?;
+
+    Ok(())
+}
+
+fn compute_mean(ratings: &HashMap<i32, f64>) -> f64 {
+    if ratings.is_empty() {
+        return 0.0;
+    }
+
+    let mut mean = 0.0;
+    for (_, rating) in ratings {
+        mean += rating;
+    }
+    mean / ratings.len() as f64
+}
+
+fn main() -> Result<(), Error> {
+    let url = "postgres://postgres:@localhost/movie-lens-small";
+    let conn = establish_connection(url)?;
+
+    let controller = MovieLensSmallController::new()?;
+
+    let users_iterator = controller.users_by_chunks(10000);
+    for user_chunk in users_iterator {
+        let maped_ratings = controller.maped_ratings_by(&user_chunk)?;
+        for user in user_chunk {
+            let user_id = user.get_id();
+            if maped_ratings.contains_key(&user_id) {
+                let mean = compute_mean(&maped_ratings[&user_id]);
+                create_mean(&conn, user_id, mean)?;
+            } else {
+                create_mean(&conn, user_id, 0.0)?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/controllers/movie-lens-small/src/lib.rs
+++ b/controllers/movie-lens-small/src/lib.rs
@@ -4,7 +4,11 @@ extern crate diesel;
 pub mod models;
 pub mod schema;
 
-use crate::models::{movies::Movie, ratings::Rating, users::User};
+use crate::models::{
+    movies::Movie,
+    ratings::Rating,
+    users::{Mean, User},
+};
 use crate::schema::{movies, ratings, users};
 use anyhow::Error;
 use controller::{error::ErrorKind, Controller, MapedRatings, Ratings, SearchBy};
@@ -184,5 +188,18 @@ impl Controller<User, i32, Movie, i32> for MovieLensSmallController {
 
     fn get_range(&self) -> (f64, f64) {
         (0.5, 5.)
+    }
+    fn get_means(&self, users: &Vec<User>) -> HashMap<i32, f64> {
+        let means = Mean::belonging_to(users)
+            .load::<Mean>(&self.pg_conn)
+            .unwrap();
+
+        let mut means_by_user = HashMap::new();
+
+        for mean in means {
+            means_by_user.insert(mean.user_id, mean.val);
+        }
+
+        means_by_user
     }
 }

--- a/controllers/movie-lens-small/src/models/users.rs
+++ b/controllers/movie-lens-small/src/models/users.rs
@@ -1,4 +1,4 @@
-use crate::schema::users;
+use crate::schema::{means, users};
 use controller::Entity;
 
 // To query data from the database
@@ -20,4 +20,19 @@ impl Entity for User {
 #[table_name = "users"]
 pub struct NewUser {
     pub id: i32,
+}
+
+#[derive(Debug, Clone, Identifiable, Queryable, Associations)]
+#[belongs_to(User)]
+pub struct Mean {
+    pub id: i32,
+    pub user_id: i32,
+    pub val: f64,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[table_name = "means"]
+pub struct NewMean {
+    pub user_id: i32,
+    pub val: f64,
 }

--- a/controllers/movie-lens-small/src/schema.rs
+++ b/controllers/movie-lens-small/src/schema.rs
@@ -1,4 +1,12 @@
 table! {
+    means (id) {
+        id -> Int4,
+        user_id -> Int4,
+        val -> Float8,
+    }
+}
+
+table! {
     movies (id) {
         id -> Int4,
         title -> Varchar,
@@ -21,10 +29,12 @@ table! {
     }
 }
 
+joinable!(means -> users (user_id));
 joinable!(ratings -> movies (movie_id));
 joinable!(ratings -> users (user_id));
 
 allow_tables_to_appear_in_same_query!(
+    means,
     movies,
     ratings,
     users,

--- a/controllers/movie-lens/migrations/2020-06-15-002009_create_means/down.sql
+++ b/controllers/movie-lens/migrations/2020-06-15-002009_create_means/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE means;

--- a/controllers/movie-lens/migrations/2020-06-15-002009_create_means/up.sql
+++ b/controllers/movie-lens/migrations/2020-06-15-002009_create_means/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+CREATE TABLE means
+(
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    val FLOAT NOT NULL
+)

--- a/controllers/movie-lens/src/bin/load_means.rs
+++ b/controllers/movie-lens/src/bin/load_means.rs
@@ -1,0 +1,57 @@
+use anyhow::Error;
+use controller::{Controller, Entity};
+use diesel::pg::PgConnection;
+use diesel::{insert_into, prelude::*};
+use movie_lens::establish_connection;
+use movie_lens::models::{
+    movies::{Movie, NewMovie},
+    ratings::NewRating,
+    users::{NewMean, NewUser, User},
+};
+use movie_lens::schema::{means, movies, ratings, users};
+use movie_lens::MovieLensController;
+use std::collections::HashMap;
+
+fn insert_means(conn: &PgConnection, new_means: &Vec<NewMean>) -> Result<(), Error> {
+    insert_into(means::table).values(new_means).execute(conn)?;
+
+    Ok(())
+}
+
+fn compute_mean(ratings: &HashMap<i32, f64>) -> f64 {
+    if ratings.is_empty() {
+        return 0.0;
+    }
+
+    let mut mean = 0.0;
+    for (_, rating) in ratings {
+        mean += rating;
+    }
+    mean / ratings.len() as f64
+}
+
+fn main() -> Result<(), Error> {
+    let url = "postgres://postgres:@localhost/movie-lens";
+    let conn = establish_connection(url)?;
+
+    let controller = MovieLensController::new()?;
+
+    let users_iterator = controller.users_by_chunks(10000);
+    for user_chunk in users_iterator {
+        println!("Inserting new chunk");
+        let mut mean_chunk = Vec::new();
+        let maped_ratings = controller.maped_ratings_by(&user_chunk)?;
+        for user in user_chunk {
+            let user_id = user.get_id();
+            if maped_ratings.contains_key(&user_id) {
+                let mean = compute_mean(&maped_ratings[&user_id]);
+                mean_chunk.push(NewMean { user_id, val: mean });
+            } else {
+                mean_chunk.push(NewMean { user_id, val: 0.0 });
+            }
+        }
+        insert_means(&conn, &mean_chunk)?;
+    }
+
+    Ok(())
+}

--- a/controllers/movie-lens/src/lib.rs
+++ b/controllers/movie-lens/src/lib.rs
@@ -4,8 +4,12 @@ extern crate diesel;
 pub mod models;
 pub mod schema;
 
-use crate::models::{movies::Movie, ratings::Rating, users::User};
-use crate::schema::{movies, ratings, users};
+use crate::models::{
+    movies::Movie,
+    ratings::Rating,
+    users::{Mean, User},
+};
+use crate::schema::{means, movies, ratings, users};
 use anyhow::Error;
 use controller::{error::ErrorKind, Controller, MapedRatings, Ratings, SearchBy};
 use diesel::pg::PgConnection;
@@ -185,6 +189,19 @@ impl Controller<User, i32, Movie, i32> for MovieLensController {
 
     fn get_range(&self) -> (f64, f64) {
         (0.5, 5.)
+    }
+    fn get_means(&self, users: &Vec<User>) -> HashMap<i32, f64> {
+        let means = Mean::belonging_to(users)
+            .load::<Mean>(&self.pg_conn)
+            .unwrap();
+
+        let mut means_by_user = HashMap::new();
+
+        for mean in means {
+            means_by_user.insert(mean.user_id, mean.val);
+        }
+
+        means_by_user
     }
 }
 

--- a/controllers/movie-lens/src/models/users.rs
+++ b/controllers/movie-lens/src/models/users.rs
@@ -1,4 +1,4 @@
-use crate::schema::users;
+use crate::schema::{means, users};
 use controller::Entity;
 
 // To query data from the database
@@ -20,4 +20,19 @@ impl Entity for User {
 #[table_name = "users"]
 pub struct NewUser {
     pub id: i32,
+}
+
+#[derive(Debug, Clone, Identifiable, Queryable, Associations)]
+#[belongs_to(User)]
+pub struct Mean {
+    pub id: i32,
+    pub user_id: i32,
+    pub val: f64,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[table_name = "means"]
+pub struct NewMean {
+    pub user_id: i32,
+    pub val: f64,
 }

--- a/controllers/movie-lens/src/schema.rs
+++ b/controllers/movie-lens/src/schema.rs
@@ -1,4 +1,12 @@
 table! {
+    means (id) {
+        id -> Int4,
+        user_id -> Int4,
+        val -> Float8,
+    }
+}
+
+table! {
     movies (id) {
         id -> Int4,
         title -> Varchar,
@@ -21,10 +29,12 @@ table! {
     }
 }
 
+joinable!(means -> users (user_id));
 joinable!(ratings -> movies (movie_id));
 joinable!(ratings -> users (user_id));
 
 allow_tables_to_appear_in_same_query!(
+    means,
     movies,
     ratings,
     users,

--- a/controllers/shelves/src/lib.rs
+++ b/controllers/shelves/src/lib.rs
@@ -174,6 +174,9 @@ impl Controller<User, i32, Book, i32> for ShelvesController {
     fn get_range(&self) -> (f64, f64) {
         (0., 5.)
     }
+    fn get_means(&self, users: &Vec<User>) -> HashMap<i32, f64> {
+        todo!()
+    }
 }
 
 #[cfg(feature = "test-controller")]

--- a/controllers/simple-movie/migrations/2020-06-14-233409_create_means/down.sql
+++ b/controllers/simple-movie/migrations/2020-06-14-233409_create_means/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE means;

--- a/controllers/simple-movie/migrations/2020-06-14-233409_create_means/up.sql
+++ b/controllers/simple-movie/migrations/2020-06-14-233409_create_means/up.sql
@@ -1,0 +1,8 @@
+-- Your SQL goes here
+
+CREATE TABLE means
+(
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    val FLOAT NOT NULL
+)

--- a/controllers/simple-movie/src/bin/load_means.rs
+++ b/controllers/simple-movie/src/bin/load_means.rs
@@ -1,0 +1,56 @@
+use anyhow::Error;
+use controller::{Controller, Entity};
+use diesel::pg::PgConnection;
+use diesel::{insert_into, prelude::*};
+use simple_movie::establish_connection;
+use simple_movie::models::{
+    movies::{Movie, NewMovie},
+    ratings::NewRating,
+    users::{NewMean, NewUser, User},
+};
+use simple_movie::schema::{means, movies, ratings, users};
+use simple_movie::SimpleMovieController;
+use std::collections::HashMap;
+
+fn create_mean(conn: &PgConnection, user_id: i32, mean: f64) -> Result<(), Error> {
+    let new_mean = NewMean { user_id, val: mean };
+
+    insert_into(means::table).values(&new_mean).execute(conn)?;
+
+    Ok(())
+}
+
+fn compute_mean(ratings: &HashMap<i32, f64>) -> f64 {
+    if ratings.is_empty() {
+        return 0.0;
+    }
+
+    let mut mean = 0.0;
+    for (_, rating) in ratings {
+        mean += rating;
+    }
+    mean / ratings.len() as f64
+}
+
+fn main() -> Result<(), Error> {
+    let url = "postgres://postgres:@localhost/simple-movie";
+    let conn = establish_connection(url)?;
+
+    let controller = SimpleMovieController::new()?;
+
+    let users_iterator = controller.users_by_chunks(10000);
+    for user_chunk in users_iterator {
+        let maped_ratings = controller.maped_ratings_by(&user_chunk)?;
+        for user in user_chunk {
+            let user_id = user.get_id();
+            if maped_ratings.contains_key(&user_id) {
+                let mean = compute_mean(&maped_ratings[&user_id]);
+                create_mean(&conn, user_id, mean)?;
+            } else {
+                create_mean(&conn, user_id, 0.0)?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/controllers/simple-movie/src/lib.rs
+++ b/controllers/simple-movie/src/lib.rs
@@ -4,7 +4,11 @@ extern crate diesel;
 pub mod models;
 pub mod schema;
 
-use crate::models::{movies::Movie, ratings::Rating, users::User};
+use crate::models::{
+    movies::Movie,
+    ratings::Rating,
+    users::{Mean, User},
+};
 use crate::schema::{movies, ratings, users};
 use anyhow::Error;
 use controller::{error::ErrorKind, Controller, MapedRatings, Ratings, SearchBy};
@@ -204,6 +208,19 @@ impl Controller<User, i32, Movie, i32> for SimpleMovieController {
 
     fn get_range(&self) -> (f64, f64) {
         (1., 5.)
+    }
+    fn get_means(&self, users: &Vec<User>) -> HashMap<i32, f64> {
+        let means = Mean::belonging_to(users)
+            .load::<Mean>(&self.pg_conn)
+            .unwrap();
+
+        let mut means_by_user = HashMap::new();
+
+        for mean in means {
+            means_by_user.insert(mean.user_id, mean.val);
+        }
+
+        means_by_user
     }
 }
 

--- a/controllers/simple-movie/src/models/users.rs
+++ b/controllers/simple-movie/src/models/users.rs
@@ -1,4 +1,4 @@
-use crate::schema::users;
+use crate::schema::{means, users};
 use common_macros::hash_map;
 use controller::Entity;
 use std::collections::HashMap;
@@ -29,4 +29,19 @@ impl Entity for User {
 #[table_name = "users"]
 pub struct NewUser<'a> {
     pub name: &'a str,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[table_name = "means"]
+pub struct NewMean {
+    pub user_id: i32,
+    pub val: f64,
+}
+
+#[derive(Debug, Clone, Identifiable, Queryable, Associations)]
+#[belongs_to(User)]
+pub struct Mean {
+    pub id: i32,
+    pub user_id: i32,
+    pub val: f64,
 }

--- a/controllers/simple-movie/src/schema.rs
+++ b/controllers/simple-movie/src/schema.rs
@@ -1,4 +1,12 @@
 table! {
+    means (id) {
+        id -> Int4,
+        user_id -> Int4,
+        val -> Float8,
+    }
+}
+
+table! {
     movies (id) {
         id -> Int4,
         name -> Varchar,
@@ -21,7 +29,13 @@ table! {
     }
 }
 
+joinable!(means -> users (user_id));
 joinable!(ratings -> movies (movie_id));
 joinable!(ratings -> users (user_id));
 
-allow_tables_to_appear_in_same_query!(movies, ratings, users,);
+allow_tables_to_appear_in_same_query!(
+    means,
+    movies,
+    ratings,
+    users,
+);

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.7"
 simple-movie = { version = "*", path = "../controllers/simple-movie" }
 movie-lens-small = { version = "*", path = "../controllers/movie-lens-small" }
 movie-lens= { version = "*", path = "../controllers/movie-lens" }
+shelves= { version = "*", path = "../controllers/shelves" }
 thiserror = "1.0.19"
 
 [features]

--- a/engine/src/distances/items.rs
+++ b/engine/src/distances/items.rs
@@ -5,6 +5,7 @@ use num_traits::float::Float;
 use std::{
     cmp::{Ordering, Reverse},
     collections::{BinaryHeap, HashMap, HashSet},
+    fmt::Debug,
     hash::Hash,
     ops::{Add, AddAssign, Div, Mul, Sub},
 };
@@ -128,6 +129,17 @@ where
                 self.means.insert(id.to_owned(), mean);
                 self.mfreq.insert(id.to_owned(), (0, ratings.len()));
             }
+        }
+    }
+
+    pub fn add_new_means(&mut self, new_means: &HashMap<UserId, Value>)
+    where
+        UserId: Clone,
+        Value: Float,
+    {
+        for (id, mean) in new_means {
+            self.means.insert(id.clone(), *mean);
+            self.mfreq.insert(id.clone(), (0, 1));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ fn database_connected_prompt<C, User, UserId, Item, ItemId>(
 ) -> Result<(), Error>
 where
     C: Controller<User, UserId, Item, ItemId>,
-    User: Entity<Id = UserId> + ToTable,
+    User: Entity<Id = UserId> + ToTable + Clone,
     Item: Entity<Id = ItemId> + ToTable + Clone,
     UserId: Hash + Eq + Display + Clone + Default,
     ItemId: Hash + Eq + Display + Clone,


### PR DESCRIPTION
Fixed #31 .
Currently the function is obtaining a lot of ratings of a lot of users only to compute the mean of each user, but now each controller has a migration to create a new Table "Means". Also each controller has a binary to calculate the means of each user after load them, so in the item based prediction function is not needed to request all the ratings, just the means.