### PR TITLE
Turn the AdjCosine of Engine and Matrix into Rc's of RefCell

### DIFF
--- a/engine/src/distances/items.rs
+++ b/engine/src/distances/items.rs
@@ -111,6 +111,17 @@ where
         }
     }
 
+    pub fn set_mean_for(&mut self, user_id: &UserId, new: Value) {
+        if let Some(mean) = self.means.get_mut(user_id) {
+            *mean = new;
+        }
+    }
+
+    pub fn del_mean_for(&mut self, user_id: &UserId) {
+        self.means.remove(user_id);
+        self.mfreq.remove(user_id);
+    }
+
     pub fn shrink_means(&mut self)
     where
         UserId: Clone,

--- a/src/main.rs
+++ b/src/main.rs
@@ -641,7 +641,14 @@ where
 
                     Statement::EnterMatrix(m, n, method) => match method {
                         ItemMethod::AdjCosine => {
-                            let matrix = SimilarityMatrix::new(&controller, &config, m, n);
+                            let adj_cosine = engine.clone_rc_adj_cosine();
+                            let matrix = SimilarityMatrix::with_cache(
+                                &controller,
+                                &config,
+                                adj_cosine,
+                                m,
+                                n,
+                            );
                             chunked_matrix_prompt(&controller, matrix, name, rl)?;
                         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -343,6 +343,32 @@ where
                             Ok(rating) => {
                                 println!("Successfully inserted! Yay!");
                                 println!("{}", rating.to_table());
+
+                                match controller.means_for(&[user]) {
+                                    Ok(means) => {
+                                        if let Some(mean) = means.get(&user_id) {
+                                            engine.maybe_update_mean_for(&user_id, *mean);
+                                        } else {
+                                            log::error!(
+                                                "Expected a calculated mean value for user({})",
+                                                user_id
+                                            );
+                                            log::error!("Got nothing instead");
+                                            panic!(
+                                                "No calculated mean for user({}), broken invariant on insertion of rating",
+                                                user_id
+                                            );
+                                        }
+                                    }
+
+                                    Err(e) => {
+                                        log::error!("Couldn't get mean for user({})", user_id);
+                                        log::error!("Got error: {}", e);
+                                        log::error!("Maybe check the database");
+                                        log::error!("Deleting cached mean on adj_cosine");
+                                        engine.maybe_delete_mean_for(&user_id);
+                                    }
+                                }
                             }
 
                             Err(e) => {
@@ -388,6 +414,32 @@ where
                             Ok(rating) => {
                                 println!("Successfully updated! Yay!");
                                 println!("{}", rating.to_table());
+
+                                match controller.means_for(&[user]) {
+                                    Ok(means) => {
+                                        if let Some(mean) = means.get(&user_id) {
+                                            engine.maybe_update_mean_for(&user_id, *mean);
+                                        } else {
+                                            log::error!(
+                                                "Expected a calculated mean value for user({})",
+                                                user_id
+                                            );
+                                            log::error!("Got nothing instead");
+                                            panic!(
+                                                "No calculated mean for user({}), broken invariant on update of rating",
+                                                user_id
+                                            );
+                                        }
+                                    }
+
+                                    Err(e) => {
+                                        log::error!("Couldn't get mean for user({})", user_id);
+                                        log::error!("Got error: {}", e);
+                                        log::error!("Maybe check the database");
+                                        log::error!("Deleting cached mean on adj_cosine");
+                                        engine.maybe_delete_mean_for(&user_id);
+                                    }
+                                }
                             }
 
                             Err(e) => {
@@ -427,6 +479,24 @@ where
                             Ok(rating) => {
                                 println!("Successfully removed! Yay?");
                                 println!("{}", rating.to_table());
+
+                                match controller.means_for(&[user]) {
+                                    Ok(means) => {
+                                        if let Some(mean) = means.get(&user_id) {
+                                            engine.maybe_update_mean_for(&user_id, *mean);
+                                        } else {
+                                            engine.maybe_delete_mean_for(&user_id);
+                                        }
+                                    }
+
+                                    Err(e) => {
+                                        log::error!("Couldn't get mean for user({})", user_id);
+                                        log::error!("Got error: {}", e);
+                                        log::error!("Maybe check the database");
+                                        log::error!("Deleting cached mean on adj_cosine");
+                                        engine.maybe_delete_mean_for(&user_id);
+                                    }
+                                }
                             }
 
                             Err(e) => {


### PR DESCRIPTION
Basically now we have `Rc<RefCell<AdjCosine<_>>>`, explaining this a little bit:

- `Rc` is a reference counting pointer, allowing us to share memory between structs, basically without creating a new portion of memory for the object inside, still the contents may be immutable.
- `RefCell` allows us to introduce interior mutability inside the `Rc` so Engine and Matrix are allowed to mutate the same portion of shared memory. (edit: Rust borrowing rules are still present in this `RefCell` but dynamically on runtime and if one is broken the whole program will panic).